### PR TITLE
Updated IGVC Emergency Stop Transmitter Code

### DIFF
--- a/IGVC/src/emergency_stop/transmitter/makefile
+++ b/IGVC/src/emergency_stop/transmitter/makefile
@@ -2,4 +2,9 @@ makeCompile: transmitter.c
 	avr-gcc -g -O3 -mmcu=atmega8 -c transmitter.c 
 	avr-gcc -g -O3 -mmcu=atmega8 -o transmitter.elf ./transmitter.o
 	avr-objcopy -j .text -j .data -O ihex transmitter.elf transmitter.hex
+upload: transmitter.hex
+	sudo avrdude -c USBasp -p atmega8 -U flash:w:transmitter.hex:i
+setfuse: 
+	sudo avrdude -c USBasp -p atmega8 -U lfuse:w:0xd2:m -U hfuse:w:0xd9:m 
+
 	

--- a/IGVC/src/emergency_stop/transmitter/transmitter.c
+++ b/IGVC/src/emergency_stop/transmitter/transmitter.c
@@ -36,7 +36,8 @@
 /**
  * @brief Operating Frequency of uC in Hertz.
  */
-#define F_CPU 2000000UL
+//#define F_CPU 2000000UL
+#define F_CPU 4000000
 
 /**
  * @brief Baud rate of RS-232 communication in bps.


### PR DESCRIPTION
Updated the code to operate at 4MHz due to unknown issues with current operations. Also modified the makefile to have an 'upload' command and 'setfuse' for easier programming and configuration. Will need to modify the set fuse to configure the Atmega8 to 4MHz internally. Right now it sets it to 2MHz as the original specification states.